### PR TITLE
Add returnfrom.space showcase firmware

### DIFF
--- a/showcase/returnfrom.space/Console/board.py
+++ b/showcase/returnfrom.space/Console/board.py
@@ -1,0 +1,36 @@
+from machine import Pin, UART
+try:
+    import usb_hid
+    from adafruit_hid.keyboard import Keyboard
+    from adafruit_hid.keycode import Keycode
+except ImportError:
+    usb_hid = None
+    Keyboard = None
+    Keycode = None
+
+# Mapping of 16 tactile switches to keyboard keys
+KEY_PINS = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+KEYS = [Pin(pin, Pin.IN, Pin.PULL_UP) for pin in KEY_PINS]
+
+uart = UART(0, baudrate=115200)
+
+# Key codes for each tactile switch
+KEY_CODES = [
+    Keycode.A, Keycode.B, Keycode.C, Keycode.D,
+    Keycode.E, Keycode.F, Keycode.G, Keycode.H,
+    Keycode.I, Keycode.J, Keycode.K, Keycode.L,
+    Keycode.M, Keycode.N, Keycode.O, Keycode.P,
+] if Keycode else [0] * 16
+
+keyboard = Keyboard(usb_hid.devices) if usb_hid else None
+
+
+def read_keys():
+    """Read key states, send bytes over UART and optional HID presses."""
+    states = [not key.value() for key in KEYS]
+    uart.write(bytes(states))
+    if keyboard:
+        for pressed, code in zip(states, KEY_CODES):
+            if pressed:
+                keyboard.send(code)
+

--- a/showcase/returnfrom.space/Delta/board.py
+++ b/showcase/returnfrom.space/Delta/board.py
@@ -1,0 +1,20 @@
+from machine import Pin, I2C, ADC, DAC, UART
+import ssd1306
+
+# Initialize I2C for SSD1306 display
+i2c = I2C(0, scl=Pin(3), sda=Pin(4))
+DISPLAY = ssd1306.SSD1306_I2C(128, 64, i2c)
+
+# DAC output
+try:
+    dac = DAC(Pin(25))
+except Exception:
+    dac = None
+
+# ADC input sampled at 8 kHz
+adc = ADC(Pin(32))
+SAMPLE_RATE = 8000
+
+# UART input
+uart = UART(1, baudrate=115200)
+

--- a/showcase/returnfrom.space/README.md
+++ b/showcase/returnfrom.space/README.md
@@ -1,0 +1,16 @@
+# returnfrom.space Showcase
+
+This directory contains firmware for the **returnfrom.space** showcase project.
+Hardware kits can be obtained from [returnfrom.space](https://returnfrom.space).
+
+Edit the firmware using [Thonny](https://thonny.org/) and upload it to the boards.
+
+## Boards
+
+- **Console** &mdash; RP2040 based. Configured as a USB keyboard with 16 tactile
+  switches. Provides UART output at 115200&nbsp;bps.
+- **SEB** &mdash; ESP32-S2 based. Includes drivers for an SSD1306 display, DAC and
+  ADC sampled at 8&nbsp;kHz, with UART input.
+- **Delta** &mdash; ESP32-S2 based. Similar to SEB with its own pin mappings and
+  peripherals.
+

--- a/showcase/returnfrom.space/SEB/board.py
+++ b/showcase/returnfrom.space/SEB/board.py
@@ -1,0 +1,20 @@
+from machine import Pin, I2C, ADC, DAC, UART
+import ssd1306
+
+# Initialize I2C for SSD1306 display
+i2c = I2C(0, scl=Pin(1), sda=Pin(2))
+DISPLAY = ssd1306.SSD1306_I2C(128, 64, i2c)
+
+# DAC output
+try:
+    dac = DAC(Pin(17))
+except Exception:
+    dac = None
+
+# ADC input sampled at 8 kHz
+adc = ADC(Pin(34))
+SAMPLE_RATE = 8000
+
+# UART input
+uart = UART(1, baudrate=115200)
+


### PR DESCRIPTION
## Summary
- add a new showcase project called **returnfrom.space**
- provide board definitions for Console (RP2040), SEB and Delta (ESP32-S2)
- improve Console HID example
- add project README with hardware and Thonny instructions

## Testing
- `python -m py_compile showcase/returnfrom.space/Console/board.py showcase/returnfrom.space/SEB/board.py showcase/returnfrom.space/Delta/board.py`


------
https://chatgpt.com/codex/tasks/task_e_683f8a6c6a64832184f4cc124e5fd3a1