### PR TITLE
Add hardware notes and keypad scanning

### DIFF
--- a/showcase/returnfrom.space/Console/board.py
+++ b/showcase/returnfrom.space/Console/board.py
@@ -1,0 +1,63 @@
+from machine import Pin, UART
+import time
+try:
+    import usb_hid
+    from adafruit_hid.keyboard import Keyboard
+    from adafruit_hid.keycode import Keycode
+except ImportError:
+    usb_hid = None
+    Keyboard = None
+    Keycode = None
+
+# Pin mapping derived from the numpad schematic (SW1..SW16)
+ROW_PINS = [Pin(i, Pin.OUT) for i in (0, 1, 2, 3)]
+COL_PINS = [Pin(i, Pin.IN, Pin.PULL_UP) for i in (4, 5, 6, 7)]
+
+uart = UART(0, baudrate=115200)
+
+KEY_CODES = [
+    Keycode.A, Keycode.B, Keycode.C, Keycode.D,
+    Keycode.E, Keycode.F, Keycode.G, Keycode.H,
+    Keycode.I, Keycode.J, Keycode.K, Keycode.L,
+    Keycode.M, Keycode.N, Keycode.O, Keycode.P,
+] if Keycode else [0] * 16
+
+keyboard = Keyboard(usb_hid.devices) if usb_hid else None
+
+DEBOUNCE_MS = 20
+_last_raw = [0] * 16
+_last_change = [0] * 16
+_state = [0] * 16
+
+
+def _scan_matrix():
+    states = [0] * 16
+    for r, rpin in enumerate(ROW_PINS):
+        rpin.low()
+        time.sleep_us(20)
+        for c, cpin in enumerate(COL_PINS):
+            idx = r * 4 + c
+            states[idx] = not cpin.value()
+        rpin.high()
+    return states
+
+
+def read_keys():
+    """Scan matrix with software debouncing and send states."""
+    raw = _scan_matrix()
+    now = time.ticks_ms()
+    changed = False
+    for i, val in enumerate(raw):
+        if val != _last_raw[i]:
+            _last_raw[i] = val
+            _last_change[i] = now
+        elif time.ticks_diff(now, _last_change[i]) >= DEBOUNCE_MS:
+            if _state[i] != _last_raw[i]:
+                _state[i] = _last_raw[i]
+                changed = True
+    if changed:
+        uart.write(bytes(_state))
+        if keyboard:
+            for pressed, code in zip(_state, KEY_CODES):
+                if pressed:
+                    keyboard.send(code)

--- a/showcase/returnfrom.space/README.md
+++ b/showcase/returnfrom.space/README.md
@@ -1,0 +1,18 @@
+# returnfrom.space Showcase
+
+This directory contains firmware for the **returnfrom.space** showcase project.
+Hardware kits can be obtained from [returnfrom.space](https://returnfrom.space).
+The project now also ships a `Hardware` folder containing KiCad design files for
+the boards.
+
+Edit the firmware using [Thonny](https://thonny.org/) and upload it to the boards.
+
+## Boards
+
+- **Console** &mdash; RP2040 based. Configured as a USB keyboard with 16 tactile
+  switches. Provides UART output at 115200&nbsp;bps.
+- **SEB** &mdash; ESP32-S2 based. Includes drivers for an SSD1306 display, DAC and
+  ADC sampled at 8&nbsp;kHz, with UART input.
+- **Sigma** &mdash; ESP32-S2 based. Similar to SEB with its own pin mappings and
+  peripherals.
+

--- a/showcase/returnfrom.space/SEB/board.py
+++ b/showcase/returnfrom.space/SEB/board.py
@@ -1,0 +1,20 @@
+from machine import Pin, I2C, ADC, DAC, UART
+import ssd1306
+
+# Initialize I2C for SSD1306 display
+i2c = I2C(0, scl=Pin(1), sda=Pin(2))
+DISPLAY = ssd1306.SSD1306_I2C(128, 64, i2c)
+
+# DAC output
+try:
+    dac = DAC(Pin(17))
+except Exception:
+    dac = None
+
+# ADC input sampled at 8 kHz
+adc = ADC(Pin(34))
+SAMPLE_RATE = 8000
+
+# UART input
+uart = UART(1, baudrate=115200)
+

--- a/showcase/returnfrom.space/Sigma/board.py
+++ b/showcase/returnfrom.space/Sigma/board.py
@@ -1,0 +1,20 @@
+from machine import Pin, I2C, ADC, DAC, UART
+import ssd1306
+
+# Initialize I2C for SSD1306 display
+i2c = I2C(0, scl=Pin(3), sda=Pin(4))
+DISPLAY = ssd1306.SSD1306_I2C(128, 64, i2c)
+
+# DAC output
+try:
+    dac = DAC(Pin(25))
+except Exception:
+    dac = None
+
+# ADC input sampled at 8 kHz
+adc = ADC(Pin(32))
+SAMPLE_RATE = 8000
+
+# UART input
+uart = UART(1, baudrate=115200)
+


### PR DESCRIPTION
## Summary
- mention the new Hardware folder in the project README
- implement keypad matrix scanning with debouncing for the Console board

## Testing
- `python -m py_compile showcase/returnfrom.space/Console/board.py showcase/returnfrom.space/SEB/board.py showcase/returnfrom.space/Sigma/board.py`


------
https://chatgpt.com/codex/tasks/task_e_683f8a6c6a64832184f4cc124e5fd3a1